### PR TITLE
fix: correct on.path matching for actions

### DIFF
--- a/.github/workflows/publish-nuget-core3.yml
+++ b/.github/workflows/publish-nuget-core3.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
     paths:
-      - src/TTools.Configuration.KeyedOptions.Core3/
-      - src/TTools.Configuration.KeyedOptions/
+      - src/TTools.Configuration.KeyedOptions.Core3/**
+      - src/TTools.Configuration.KeyedOptions/**
 jobs:
   publish_netcore3:
     name: Publish .NET Core 3.1 Library to NuGet

--- a/.github/workflows/publish-nuget-net6.yml
+++ b/.github/workflows/publish-nuget-net6.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
     paths:
-      - src/TTools.Configuration.KeyedOptions.Net6/
-      - src/TTools.Configuration.KeyedOptions/
+      - src/TTools.Configuration.KeyedOptions.Net6/**
+      - src/TTools.Configuration.KeyedOptions/**
 jobs:
   publish_net6:
     name: Publish .NET 6 Library to NuGet


### PR DESCRIPTION
This PR fixes an issue where publish actions wouldn't be run due to bad path specs.