### PR TITLE
fix: change LangVersion of .NET Core 3.1 project

### DIFF
--- a/.github/workflows/publish-nuget-core3.yml
+++ b/.github/workflows/publish-nuget-core3.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Publish NuGet Package
         id: publish_nuget
-        uses: rohith/publish-nuget@v2
+        uses: alirezanet/publish-nuget@v3.0.0
         with:
           PROJECT_FILE_PATH: src/TTools.Configuration.KeyedOptions.Core3/TTools.Configuration.KeyedOptions.Core3.csproj
           PACKAGE_NAME: TTools.Configuration.KeyedOptions.Core3

--- a/.github/workflows/publish-nuget-net6.yml
+++ b/.github/workflows/publish-nuget-net6.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Publish NuGet Package
         id: publish_nuget
-        uses: rohith/publish-nuget@v2
+        uses: alirezanet/publish-nuget@v3.0.0
         with:
           PROJECT_FILE_PATH: src/TTools.Configuration.KeyedOptions.Net6/TTools.Configuration.KeyedOptions.Net6.csproj
           PACKAGE_NAME: TTools.Configuration.KeyedOptions.Net6

--- a/src/TTools.Configuration.KeyedOptions.Core3/TTools.Configuration.KeyedOptions.Core3.csproj
+++ b/src/TTools.Configuration.KeyedOptions.Core3/TTools.Configuration.KeyedOptions.Core3.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Nullable>enable</Nullable>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/TTools.Configuration.KeyedOptions.Shared/TTools.Configuration.KeyedOptions.Shared.csproj
+++ b/src/TTools.Configuration.KeyedOptions.Shared/TTools.Configuration.KeyedOptions.Shared.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <LangVersion>8</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>TTools.Configuration.KeyedOptions.Shared</RootNamespace>
     </PropertyGroup>


### PR DESCRIPTION
This PR fixes an issue where the `LangVersion` of the Shared project was too high for the .NET Core 3.1 package. Also bumps the NuGet publish actions version to a fork where symbols are supported.