### PR TITLE
fix: add packaging info to shared project

### DIFF
--- a/src/TTools.Configuration.KeyedOptions.Core3/TTools.Configuration.KeyedOptions.Core3.csproj
+++ b/src/TTools.Configuration.KeyedOptions.Core3/TTools.Configuration.KeyedOptions.Core3.csproj
@@ -20,7 +20,7 @@
     <PropertyGroup>
         <Authors>TTools Developers</Authors>
         <Description>KeyedOptions provides extensions to register options with predefined keys.</Description>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
         <Copyright>Copyright 2021 © TTools Development. All rights reserved.</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/ttools-dev/TTools.Configuration.KeyedOptions</RepositoryUrl>

--- a/src/TTools.Configuration.KeyedOptions.Net6/TTools.Configuration.KeyedOptions.Net6.csproj
+++ b/src/TTools.Configuration.KeyedOptions.Net6/TTools.Configuration.KeyedOptions.Net6.csproj
@@ -20,7 +20,7 @@
     <PropertyGroup>
         <Authors>TTools Developers</Authors>
         <Description>KeyedOptions provides extensions to register options with predefined keys.</Description>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
         <Copyright>Copyright 2021 © TTools Development. All rights reserved.</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/ttools-dev/TTools.Configuration.KeyedOptions</RepositoryUrl>

--- a/src/TTools.Configuration.KeyedOptions.Shared/TTools.Configuration.KeyedOptions.Shared.csproj
+++ b/src/TTools.Configuration.KeyedOptions.Shared/TTools.Configuration.KeyedOptions.Shared.csproj
@@ -11,7 +11,7 @@
     <PropertyGroup>
         <Authors>TTools Developers</Authors>
         <Description>KeyedOptions provides extensions to register options with predefined keys.</Description>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
         <Copyright>Copyright 2021 © TTools Development. All rights reserved.</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/ttools-dev/TTools.Configuration.KeyedOptions</RepositoryUrl>

--- a/src/TTools.Configuration.KeyedOptions.Shared/TTools.Configuration.KeyedOptions.Shared.csproj
+++ b/src/TTools.Configuration.KeyedOptions.Shared/TTools.Configuration.KeyedOptions.Shared.csproj
@@ -8,4 +8,14 @@
         <RootNamespace>TTools.Configuration.KeyedOptions.Shared</RootNamespace>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <Authors>TTools Developers</Authors>
+        <Description>KeyedOptions provides extensions to register options with predefined keys.</Description>
+        <Version>1.1.0</Version>
+        <Copyright>Copyright 2021 © TTools Development. All rights reserved.</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/ttools-dev/TTools.Configuration.KeyedOptions</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds packaging info the `TTools.Configuration.KeyedOptions.Shared` project file.