### PR TITLE
fix: update path of shared package in workflows

### DIFF
--- a/.github/workflows/publish-nuget-core3.yml
+++ b/.github/workflows/publish-nuget-core3.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - src/TTools.Configuration.KeyedOptions.Core3/**
-      - src/TTools.Configuration.KeyedOptions/**
+      - src/TTools.Configuration.KeyedOptions.Shared/**
 jobs:
   publish_netcore3:
     name: Publish .NET Core 3.1 Library to NuGet

--- a/.github/workflows/publish-nuget-net6.yml
+++ b/.github/workflows/publish-nuget-net6.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - src/TTools.Configuration.KeyedOptions.Net6/**
-      - src/TTools.Configuration.KeyedOptions/**
+      - src/TTools.Configuration.KeyedOptions.Shared/**
 jobs:
   publish_net6:
     name: Publish .NET 6 Library to NuGet

--- a/.github/workflows/publish-nuget-shared.yml
+++ b/.github/workflows/publish-nuget-shared.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - src/TTools.Configuration.KeyedOptions/**
+      - src/TTools.Configuration.KeyedOptions.Shared/**
 jobs:
   publish_net6:
     name: Publish .NET Standard Library to NuGet


### PR DESCRIPTION
This PR fixes an issue where Shared project changes were not being watched by workflows due to an old path